### PR TITLE
Fix module dir selinux context

### DIFF
--- a/module/template/customize.sh
+++ b/module/template/customize.sh
@@ -83,3 +83,6 @@ else
   extract "$ZIPFILE" "lib/arm64-v8a/lib$SONAME.so" "$MODPATH/zygisk" true
   mv "$MODPATH/zygisk/lib$SONAME.so" "$MODPATH/zygisk/arm64-v8a.so"
 fi
+
+ui_print "- Setting permissions"
+set_perm_recursive "$MODPATH" 0 0 0755 0644


### PR DESCRIPTION
MODDIR default context may be different on different root solutions. As we set SKIP_UNZIP, we need to use this function to set system_file context for module dir, or zygisk getModuleDir() API may not work because zygote cannot use fd with adb_data_file context.